### PR TITLE
Initial and deleted versions and conditions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@ require 'rspec/core/rake_task'
 Bundler::GemHelper.install_tasks
 RSpec::Core::RakeTask.new(:spec)
 
+task :default => :spec
+
 if RUBY_VERSION < '1.9'
   desc "Run all tests with coverage"
   RSpec::Core::RakeTask.new :coverage => :cleanup_coverage_files do |t|

--- a/lib/vestal_versions/creation.rb
+++ b/lib/vestal_versions/creation.rb
@@ -31,7 +31,8 @@ module VestalVersions
       private
         # Returns whether an initial version should be created upon creation of the parent record.
         def create_initial_version?
-          vestal_versions_options[:initial_version] == true
+          vestal_versions_options[:initial_version] == true &&
+            version_conditions_met?
         end
 
         # Creates an initial version upon creation of the parent record.

--- a/lib/vestal_versions/deletion.rb
+++ b/lib/vestal_versions/deletion.rb
@@ -27,7 +27,8 @@ module VestalVersions
       private
 
         def delete_version?
-          vestal_versions_options[:track_destroy]
+          vestal_versions_options[:track_destroy] &&
+            version_conditions_met?
         end
 
         def create_destroyed_version

--- a/lib/vestal_versions/options.rb
+++ b/lib/vestal_versions/options.rb
@@ -28,7 +28,7 @@ module VestalVersions
         #   :order => "#{options[:class_name].constantize.table_name}.#{connection.quote_column_name('number')} ASC"
         # )
 
-        class_inheritable_accessor :vestal_versions_options
+        class_attribute :vestal_versions_options
         self.vestal_versions_options = options.dup
 
         options.merge!(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,4 +17,4 @@ RSpec.configure do |c|
   end
 end
 
-Dir[File.dirname(__FILE__) + '/support/*.rb'].each { |f| require f }
+Dir[File.expand_path('../support/*.rb', __FILE__)].each{|f| require f }

--- a/spec/vestal_versions/creation_spec.rb
+++ b/spec/vestal_versions/creation_spec.rb
@@ -16,6 +16,15 @@ describe VestalVersions::Creation do
       its('versions.count'){ should == 1 }
     end
 
+    context "with :initial_version and false conditional options" do
+      before do
+        User.prepare_versioned_options(:initial_version => true,
+                                       :if              => Proc.new { false })
+      end
+
+      its('versions.count'){ should == 0 }
+    end
+
     it 'does not increase when no changes are made in an update' do
       expect {
         subject.update_attribute(:name, name)

--- a/spec/vestal_versions/deletion_spec.rb
+++ b/spec/vestal_versions/deletion_spec.rb
@@ -25,6 +25,26 @@ describe VestalVersions::Deletion do
       VestalVersions::Version.last.tag.should == 'deleted'
     end
 
+    context "when conditions aren't met" do
+      before do
+        DeletedUser.prepare_versioned_options(:dependent => :tracking,
+                                              :if => Proc.new { false })
+      end
+
+      after do
+        DeletedUser.prepare_versioned_options(:dependent => :tracking)
+      end
+
+      it "removes the original record" do
+        subject.destroy
+
+        DeletedUser.find_by_id(subject.id).should be_nil
+      end
+
+      it "doesn't create a version" do
+        expect{ subject.destroy }.to_not change{ VestalVersions::Version.count }
+      end
+    end
   end
 
   context "deleted versions" do


### PR DESCRIPTION
I've noticed that with the following options:

```
versioned dependent: :tracking, initial_version: true, unless: :really?
```

An initial version is always created and a version is always created after a deletion, no matter the result of "really?".

I guess it's up to debate whether it should behave that way or not (especially the deletion case), but, in case you think it shouldn't, here's a quick patch.

Thanks.
